### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,9 +217,9 @@ Requirements:
 - Xcode 7.1 / Swift 2.1
 - iOS 8+
 
-### Cocoapods
+### CocoaPods
 
-1. If you haven't already, [install Cocoapods](https://guides.cocoapods.org/using/getting-started.html) and [setup your project for use with Cocoapods](https://guides.cocoapods.org/using/using-cocoapods.html)
+1. If you haven't already, [install CocoaPods](https://guides.cocoapods.org/using/getting-started.html) and [setup your project for use with CocoaPods](https://guides.cocoapods.org/using/using-cocoapods.html)
 
 2. Add `Fisticuffs` to your `Podfile`:
 


### PR DESCRIPTION

This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>
<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
