### PR TITLE
Improve fix for UICollectionView crash

### DIFF
--- a/Tests/DataSourceSpec.swift
+++ b/Tests/DataSourceSpec.swift
@@ -32,6 +32,7 @@ class DataSourceSpec: QuickSpec {
         var selections: Observable<[Int]>!
         var selection: Observable<Int?>!
         var disabled: Observable<[Int]>!
+        var view: FauxDataSourceView!
         var dataSource: DataSource<Int, FauxDataSourceView>!
 
         beforeEach {
@@ -39,7 +40,8 @@ class DataSourceSpec: QuickSpec {
             selections = Observable([])
             selection = Observable(nil)
             disabled = Observable([])
-            dataSource = DataSource(subscribable: observable, view: FauxDataSourceView())
+            view = FauxDataSourceView()
+            dataSource = DataSource(subscribable: observable, view: view)
             dataSource.selections = selections
             dataSource.selection = selection
             dataSource.disableSelectionFor(disabled)
@@ -163,7 +165,10 @@ class DataSourceSpec: QuickSpec {
         func reloadData() { }
         func insertCells(indexPaths: [IndexPath]) { }
         func deleteCells(indexPaths: [IndexPath]) { }
-        func batchUpdates(_ updates: @escaping () -> Void) { }
+        
+        func batchUpdates(_ updates: @escaping () -> Void) {
+            updates()
+        }
         
         func indexPathsForSelections() -> [IndexPath]? { return [] }
         func select(indexPath: IndexPath) { }


### PR DESCRIPTION
Wrapping all updates in calls to `performUpdate(_:completion:)` to work around crash that occurred when inserting/removing items before the collection view had done its initial load of section/item counts. See comments in code for specifics.

Additionally am calculating the changes using DataSource's `items` array & the new items from the subscribable.  Previously it was using `subscribeArray`, which did a diff of the subscribable's old value & new value.  Not sure if it was the source of any bugs, but now by using `DataSource.items` & the new items, we are definitely diffing what the UICollectionView will see in terms of updates.