### PR TITLE
Fixes compilation issue with Xcode 10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.0.7
+ - Scopes `Event<>` explicitly to `Fisticuffs.Event<>` in UIKit extensions. Fisticuffs declares `Event<>` which seems to conflict with some swiftification of `UIEvent` -> `UIControl.Event`
+
 ## 0.0.6
  - Fixes an issue in the podspec that would prevent Fisticuffs from building under the new xcode build system.
 

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ Requirements:
 2. Add `Fisticuffs` to your `Podfile`:
 
   ```
-  pod 'Fisticuffs', '0.0.6'
+  pod 'Fisticuffs', '0.0.7'
   ```
 
 3. Run `pod install`
@@ -214,7 +214,7 @@ Requirements:
 2. Add `Fisticuffs` to your `Cartfile`:
 
   ```
-  github "scoremedia/Fisticuffs" == 0.0.6
+  github "scoremedia/Fisticuffs" == 0.0.7
   ```
 
 3. Run `carthage update`

--- a/Source/UIKit/UIControl+Binding.swift
+++ b/Source/UIKit/UIControl+Binding.swift
@@ -41,10 +41,10 @@ public extension UIControl {
         }
     }
 
-    var b_onTap: Event<Void> {
+    var b_onTap: Fisticuffs.Event<Void> {
         return associatedObjectProperty(self, &b_onTap_key) { _ in
             self.addTarget(self, action: #selector(self.b_receivedOnTap(_:)), for: .touchUpInside)
-            return Event<Void>()
+            return Fisticuffs.Event<Void>()
         }
     }
 
@@ -63,7 +63,7 @@ public extension UIControl {
 
      - returns: The Event object
      */
-    func b_controlEvent(_ controlEvents: UIControlEvents) -> Event<UIEvent?> {
+    func b_controlEvent(_ controlEvents: UIControlEvents) -> Fisticuffs.Event<UIEvent?> {
         let trampolinesCollection = associatedObjectProperty(self, &trampolines_key) { _ in ControlEventTrampolineCollection() }
 
         if let trampoline = trampolinesCollection.trampolines[controlEvents.rawValue] {

--- a/Source/UIKit/UITextField+Binding.swift
+++ b/Source/UIKit/UITextField+Binding.swift
@@ -45,11 +45,11 @@ public extension UITextField {
         }
     }
 
-    var b_didBeginEditing: Event<UIEvent?> {
+    var b_didBeginEditing:Fisticuffs.Event<UIEvent?> {
         return b_controlEvent(.editingDidBegin)
     }
     
-    var b_didEndEditing: Event<UIEvent?> {
+    var b_didEndEditing: Fisticuffs.Event<UIEvent?> {
         return b_controlEvent([.editingDidEnd, .editingDidEndOnExit])
     }
     
@@ -103,11 +103,11 @@ public extension UITextField {
     }
 
     
-    var b_willClear: Event<Void> {
+    var b_willClear: Fisticuffs.Event<Void> {
         return b_delegate.willClear
     }
     
-    var b_willReturn: Event<Void> {
+    var b_willReturn: Fisticuffs.Event<Void> {
         return b_delegate.willReturn
     }
 


### PR DESCRIPTION
Fisticuffs declares `Event<>` which seems to conflict with some swiftification of `UIEvent` -> `UIControl.Event`