### PR TITLE
Adds a ComposedBindingHandler

### DIFF
--- a/Fisticuffs.xcodeproj/project.pbxproj
+++ b/Fisticuffs.xcodeproj/project.pbxproj
@@ -88,6 +88,7 @@
 		6AF784EA1D19BC2F00D57380 /* LoadImageManagerType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AF784E91D19BC2F00D57380 /* LoadImageManagerType.swift */; };
 		6AFC0AE11C738C1300294F65 /* TargetActionBindableProperty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AFC0AE01C738C1300294F65 /* TargetActionBindableProperty.swift */; };
 		6AFC0AF41C73B17200294F65 /* BindingHandlersSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AFC0AF21C73B07A00294F65 /* BindingHandlersSpec.swift */; };
+		89272118223AAC7300FBE0FF /* ComposedBindingHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89272117223AAC7300FBE0FF /* ComposedBindingHandler.swift */; };
 		8D6B81F01CF603E0005083F3 /* UIAlertAction+Binding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D6B81EF1CF603E0005083F3 /* UIAlertAction+Binding.swift */; };
 		A88FD65F1E0AD62900113717 /* ThrottleBindingHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = A88FD65E1E0AD62900113717 /* ThrottleBindingHandler.swift */; };
 		A88FD6741E0C5CE800113717 /* DispatchSource+Fisticuffs.swift in Sources */ = {isa = PBXBuildFile; fileRef = A88FD6731E0C5CE800113717 /* DispatchSource+Fisticuffs.swift */; };
@@ -342,6 +343,7 @@
 		6AF784E91D19BC2F00D57380 /* LoadImageManagerType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoadImageManagerType.swift; sourceTree = "<group>"; };
 		6AFC0AE01C738C1300294F65 /* TargetActionBindableProperty.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TargetActionBindableProperty.swift; sourceTree = "<group>"; };
 		6AFC0AF21C73B07A00294F65 /* BindingHandlersSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BindingHandlersSpec.swift; sourceTree = "<group>"; };
+		89272117223AAC7300FBE0FF /* ComposedBindingHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposedBindingHandler.swift; sourceTree = "<group>"; };
 		8D6B81EF1CF603E0005083F3 /* UIAlertAction+Binding.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIAlertAction+Binding.swift"; sourceTree = "<group>"; };
 		A88FD65E1E0AD62900113717 /* ThrottleBindingHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThrottleBindingHandler.swift; sourceTree = "<group>"; };
 		A88FD6731E0C5CE800113717 /* DispatchSource+Fisticuffs.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "DispatchSource+Fisticuffs.swift"; sourceTree = "<group>"; };
@@ -406,6 +408,7 @@
 				6AEADE711C6E7DF4008DFDBA /* DefaultBindingHandler.swift */,
 				6AEADE841C6E89B6008DFDBA /* TransformBindingHandler.swift */,
 				A88FD65E1E0AD62900113717 /* ThrottleBindingHandler.swift */,
+				89272117223AAC7300FBE0FF /* ComposedBindingHandler.swift */,
 				6AD65A2B1CDB850C00319A44 /* ComputedBindingHandler.swift */,
 				6ACC32CE1C73D18300B241EA /* OptionalTypeBindingHandler.swift */,
 				6A09EF071BFB816D005C2B81 /* Computed.swift */,
@@ -890,6 +893,7 @@
 				6A09EF281BFB816D005C2B81 /* Disposable.swift in Sources */,
 				6A09EF2D1BFB816D005C2B81 /* Observable.swift in Sources */,
 				6A10DED01CB5AE920097BB54 /* UIActivityIndicatorView+Binding.swift in Sources */,
+				89272118223AAC7300FBE0FF /* ComposedBindingHandler.swift in Sources */,
 				8D6B81F01CF603E0005083F3 /* UIAlertAction+Binding.swift in Sources */,
 				6A6B3BE11BFE2FDD00B825DB /* UIView+Binding.swift in Sources */,
 				6A09EF3E1BFB816D005C2B81 /* UITableView+Binding.swift in Sources */,

--- a/Source/ComposedBindingHandler.swift
+++ b/Source/ComposedBindingHandler.swift
@@ -1,0 +1,66 @@
+//  The MIT License (MIT)
+//
+//  Copyright (c) 2019 theScore Inc.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+import Foundation
+
+/// A `BindingHandler` whose input and output is a function of the two components `BindingHandler`s
+class ComposedBindingHandler<Control: AnyObject, InDataValue, OutDataValue, PropertyValue>: BindingHandler<Control, InDataValue, PropertyValue> {
+    let bindingHandler1: BindingHandler<Control, InDataValue, OutDataValue>
+    let bindingHandler2: BindingHandler<Control, OutDataValue, PropertyValue>
+    
+    private var bindingHandler1OldValue: OutDataValue?
+    
+    init(handler1: BindingHandler<Control, InDataValue, OutDataValue>, handler2: BindingHandler<Control, OutDataValue, PropertyValue>) {
+        self.bindingHandler1 = handler1
+        self.bindingHandler2 = handler2
+    }
+    
+    override func set(control: Control, oldValue: InDataValue?, value: InDataValue, propertySetter: @escaping PropertySetter) {
+        bindingHandler1.set(control: control, oldValue: oldValue, value: value) { [handler = self.bindingHandler2, oldValue = bindingHandler1OldValue, weak self] (control, value) in
+            handler.set(control: control, oldValue: oldValue, value: value, propertySetter: propertySetter)
+            self?.bindingHandler1OldValue = value
+        }
+    }
+    
+    override func get(control: Control, propertyGetter: @escaping PropertyGetter) throws -> InDataValue {
+        return try bindingHandler1.get(control: control, propertyGetter: { [handler = self.bindingHandler2] (control) -> OutDataValue in
+            return try! handler.get(control: control, propertyGetter: propertyGetter)
+        })
+    }
+    
+    override func dispose() {
+        bindingHandler1.dispose()
+        bindingHandler2.dispose()
+        super.dispose()
+    }
+}
+
+
+///  Composes two `BindingHandler` objcts so that the data flows through the LHS first performing and transfromations and then the RHS
+///
+/// - Parameters:
+///   - lhs: The first binding handler
+///   - rhs: the second binding handler
+/// - Returns: A binding handle that composes the functions of the two `BindingHandler`s provided
+public func && <Control: AnyObject, InDataValue, OutDataValue, PropertyValue>(lhs: BindingHandler<Control, InDataValue, OutDataValue>, rhs:BindingHandler<Control, OutDataValue, PropertyValue>) -> BindingHandler<Control, InDataValue, PropertyValue> {
+    return ComposedBindingHandler(handler1: lhs, handler2: rhs)
+}


### PR DESCRIPTION
handler is hidden behind the && operator which is reasonable common when
used for composing functions without resorting to more esoteric
characters.

This gives us a fairly nice syntax that is easy to read & follow while also hiding implementation details.

```swift
let formatter = NumberFormatter()
formatter.numberStyle = .ordinal
       
label.b_text.bind(observable,
        BindingHandlers.transform({ (value) in return Int(value) }) &&
        BindingHandlers.transform({ (value) in return formatter.string(for: value) ?? "\(value)" }) &&
        BindingHandlers.transform({ (value) in return value.uppercased() })
)
```