### PR TITLE
Makes dependency tracking methods public

### DIFF
--- a/Source/DependencyTracker.swift
+++ b/Source/DependencyTracker.swift
@@ -21,7 +21,7 @@
 //  THE SOFTWARE.
 
 
-struct DependencyTracker {
+public struct DependencyTracker {
 
     static func findDependencies(_ block: () -> Void) -> [AnySubscribableBox] {
         let stack = DependenciesCollectionStack.current
@@ -35,7 +35,7 @@ struct DependencyTracker {
         return Array(collection.dependencies)
     }
     
-    static func didReadObservable(_ subscribable: AnySubscribable) {
+    public static func didReadObservable(_ subscribable: AnySubscribable) {
         let boxed = AnySubscribableBox(subscribable: subscribable)
         DependenciesCollectionStack.current.items.last?.dependencies.insert(boxed)
     }

--- a/Source/Subscribable.swift
+++ b/Source/Subscribable.swift
@@ -28,7 +28,7 @@ open class Subscribable<Value> : AnySubscribable {
 
     public let subscriptionCollection: SubscriptionCollection<Value> = SubscriptionCollection()
 
-    open init() {}
+    public init() {}
     
     open func subscribe(_ block: @escaping (Value?, Value) -> Void) -> Disposable {
         return subscribe(SubscriptionOptions(), block: block)

--- a/Source/Subscribable.swift
+++ b/Source/Subscribable.swift
@@ -28,6 +28,8 @@ open class Subscribable<Value> : AnySubscribable {
 
     public let subscriptionCollection: SubscriptionCollection<Value> = SubscriptionCollection()
 
+    open init() {}
+    
     open func subscribe(_ block: @escaping (Value?, Value) -> Void) -> Disposable {
         return subscribe(SubscriptionOptions(), block: block)
     }

--- a/Source/SubscriptionCollection.swift
+++ b/Source/SubscriptionCollection.swift
@@ -34,7 +34,7 @@ open class SubscriptionCollection<T> {
         }
     }
     
-    func notify(time: NotifyWhen, old: T?, new: T) {
+    public func notify(time: NotifyWhen, old: T?, new: T) {
         lock.withLock {
             for s in subscriptions where s.when == time {
                 s.callback(old, new)


### PR DESCRIPTION
These methods are needed to create Subscribable subclasses that can participate in computed and fire notifications properly