### PR TITLE
Add observable initializer

### DIFF
--- a/Fisticuffs.podspec
+++ b/Fisticuffs.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "Fisticuffs"
-  s.version          = "0.0.11"
+  s.version          = "0.0.12"
   s.summary          = "Fisticuffs is a data binding framework for Swift, inspired by Knockout."
 
   s.description      = <<-DESC

--- a/Source/Observable.swift
+++ b/Source/Observable.swift
@@ -37,7 +37,7 @@ open class Observable<Value> : Subscribable<Value> {
     }
 
     //MARK: - Value property
-    
+
     open var value: Value {
         set(newValue) {
             let old = storage
@@ -54,12 +54,16 @@ open class Observable<Value> : Subscribable<Value> {
     }
 
     open override var currentValue: Value? { return value }
-    
+
     fileprivate var storage: Value
 
     //MARK: - Init
+
     public init(_ initial: Value) {
         storage = initial
     }
 
+    convenience public init(wrappedValue: Value) {
+        self.init(wrappedValue)
+    }
 }

--- a/Tests/ObservableSpec.swift
+++ b/Tests/ObservableSpec.swift
@@ -36,6 +36,14 @@ class ObservableSpec: QuickSpec {
             observable.value = "test 2"
             expect(observable.value) == "test 2"
         }
+
+        it("should initialize with wrapped value") {
+            let observable = Observable(wrappedValue: "test")
+            expect(observable.value) == "test"
+
+            observable.value = "test 2"
+            expect(observable.value) == "test 2"
+        }
         
         it("should notify observers when its value changes") {
             let observable = Observable(5)


### PR DESCRIPTION
Added `init(wrappedValue: Value)` to allow support for declaring property wrappers like `@Observable var foo: Bool = false`