### PR TITLE
Add Scheduler to subscriptions

### DIFF
--- a/Fisticuffs.xcodeproj/project.pbxproj
+++ b/Fisticuffs.xcodeproj/project.pbxproj
@@ -102,6 +102,7 @@
 		C689E1BF262260C400B66BDD /* RunLoop+Scheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = C689E1BE262260C400B66BDD /* RunLoop+Scheduler.swift */; };
 		C6D3A4CE2624F0E00090790A /* SchedulersSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6D3A4CD2624F0E00090790A /* SchedulersSpec.swift */; };
 		C6D3A4D22624F5B60090790A /* SubscribableSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6D3A4D12624F5B60090790A /* SubscribableSpec.swift */; };
+		C6D3A4EE2626519E0090790A /* MainThreadScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6D3A4ED2626519E0090790A /* MainThreadScheduler.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -239,6 +240,7 @@
 		C689E1BE262260C400B66BDD /* RunLoop+Scheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RunLoop+Scheduler.swift"; sourceTree = "<group>"; };
 		C6D3A4CD2624F0E00090790A /* SchedulersSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchedulersSpec.swift; sourceTree = "<group>"; };
 		C6D3A4D12624F5B60090790A /* SubscribableSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscribableSpec.swift; sourceTree = "<group>"; };
+		C6D3A4ED2626519E0090790A /* MainThreadScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainThreadScheduler.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -445,6 +447,7 @@
 			children = (
 				C689E1AE2622606100B66BDD /* Scheduler.swift */,
 				C689E1BA262260BB00B66BDD /* DefaultScheduler.swift */,
+				C6D3A4ED2626519E0090790A /* MainThreadScheduler.swift */,
 				C689E1B22622609500B66BDD /* DispatchQueue+Scheduler.swift */,
 				C689E1B6262260B300B66BDD /* OperationQueue+Scheduler.swift */,
 				C689E1BE262260C400B66BDD /* RunLoop+Scheduler.swift */,
@@ -655,6 +658,7 @@
 				4F66380D25C5C5FD00473132 /* UIImageView+Binding.swift in Sources */,
 				4F66380E25C5C5FD00473132 /* UIBarButtonItem+Binding.swift in Sources */,
 				4F66382E25C5C5FD00473132 /* DefaultBindingHandler.swift in Sources */,
+				C6D3A4EE2626519E0090790A /* MainThreadScheduler.swift in Sources */,
 				4F66383225C5C5FD00473132 /* OptionalType.swift in Sources */,
 				4F66382125C5C5FD00473132 /* UISearchBar+Binding.swift in Sources */,
 				4F66380225C5C5FD00473132 /* SubscriptionOptions.swift in Sources */,

--- a/Fisticuffs.xcodeproj/project.pbxproj
+++ b/Fisticuffs.xcodeproj/project.pbxproj
@@ -100,6 +100,8 @@
 		C689E1B7262260B300B66BDD /* OperationQueue+Scheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = C689E1B6262260B300B66BDD /* OperationQueue+Scheduler.swift */; };
 		C689E1BB262260BB00B66BDD /* DefaultScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = C689E1BA262260BB00B66BDD /* DefaultScheduler.swift */; };
 		C689E1BF262260C400B66BDD /* RunLoop+Scheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = C689E1BE262260C400B66BDD /* RunLoop+Scheduler.swift */; };
+		C6D3A4CE2624F0E00090790A /* SchedulersSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6D3A4CD2624F0E00090790A /* SchedulersSpec.swift */; };
+		C6D3A4D22624F5B60090790A /* SubscribableSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6D3A4D12624F5B60090790A /* SubscribableSpec.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -235,6 +237,8 @@
 		C689E1B6262260B300B66BDD /* OperationQueue+Scheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OperationQueue+Scheduler.swift"; sourceTree = "<group>"; };
 		C689E1BA262260BB00B66BDD /* DefaultScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultScheduler.swift; sourceTree = "<group>"; };
 		C689E1BE262260C400B66BDD /* RunLoop+Scheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RunLoop+Scheduler.swift"; sourceTree = "<group>"; };
+		C6D3A4CD2624F0E00090790A /* SchedulersSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchedulersSpec.swift; sourceTree = "<group>"; };
+		C6D3A4D12624F5B60090790A /* SubscribableSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscribableSpec.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -385,6 +389,8 @@
 				4F66384F25C5C66000473132 /* AnySubscribableSpec.swift */,
 				4F66385025C5C66000473132 /* Info.plist */,
 				4F66385125C5C66000473132 /* ComputedSpec.swift */,
+				C6D3A4CD2624F0E00090790A /* SchedulersSpec.swift */,
+				C6D3A4D12624F5B60090790A /* SubscribableSpec.swift */,
 			);
 			path = FisticuffsTests;
 			sourceTree = "<group>";
@@ -671,6 +677,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C6D3A4D22624F5B60090790A /* SubscribableSpec.swift in Sources */,
 				4F66385825C5C66000473132 /* DependencyTrackerSpec.swift in Sources */,
 				4F66385225C5C66000473132 /* ObservableSpec.swift in Sources */,
 				4F66385F25C5C66100473132 /* AnySubscribableSpec.swift in Sources */,
@@ -683,6 +690,7 @@
 				4F66385525C5C66000473132 /* UIKitBindingSpec.swift in Sources */,
 				4F66385625C5C66000473132 /* ObservableArraySpec.swift in Sources */,
 				4F66385325C5C66000473132 /* DisposableBagSpec.swift in Sources */,
+				C6D3A4CE2624F0E00090790A /* SchedulersSpec.swift in Sources */,
 				4F66385425C5C66000473132 /* MemoryManagementSpec.swift in Sources */,
 				4F66385925C5C66000473132 /* EventSpec.swift in Sources */,
 				4F66385C25C5C66100473132 /* BidirectionalBindingSpec.swift in Sources */,

--- a/Fisticuffs.xcodeproj/project.pbxproj
+++ b/Fisticuffs.xcodeproj/project.pbxproj
@@ -95,6 +95,11 @@
 		6A6B3BDB1BFE1D4A00B825DB /* CollectionViewSample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A6B3BDA1BFE1D4A00B825DB /* CollectionViewSample.swift */; };
 		6A6B3BF21BFE32F700B825DB /* ControlsSample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A6B3BF11BFE32F700B825DB /* ControlsSample.swift */; };
 		6A6E14C41C751925003F4EC6 /* ImageViewSample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A6E14C31C751925003F4EC6 /* ImageViewSample.swift */; };
+		C689E1AF2622606100B66BDD /* Scheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = C689E1AE2622606100B66BDD /* Scheduler.swift */; };
+		C689E1B32622609500B66BDD /* DispatchQueue+Scheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = C689E1B22622609500B66BDD /* DispatchQueue+Scheduler.swift */; };
+		C689E1B7262260B300B66BDD /* OperationQueue+Scheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = C689E1B6262260B300B66BDD /* OperationQueue+Scheduler.swift */; };
+		C689E1BB262260BB00B66BDD /* DefaultScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = C689E1BA262260BB00B66BDD /* DefaultScheduler.swift */; };
+		C689E1BF262260C400B66BDD /* RunLoop+Scheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = C689E1BE262260C400B66BDD /* RunLoop+Scheduler.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -225,6 +230,11 @@
 		6A6B3BDA1BFE1D4A00B825DB /* CollectionViewSample.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CollectionViewSample.swift; sourceTree = "<group>"; };
 		6A6B3BF11BFE32F700B825DB /* ControlsSample.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ControlsSample.swift; sourceTree = "<group>"; };
 		6A6E14C31C751925003F4EC6 /* ImageViewSample.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageViewSample.swift; sourceTree = "<group>"; };
+		C689E1AE2622606100B66BDD /* Scheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Scheduler.swift; sourceTree = "<group>"; };
+		C689E1B22622609500B66BDD /* DispatchQueue+Scheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DispatchQueue+Scheduler.swift"; sourceTree = "<group>"; };
+		C689E1B6262260B300B66BDD /* OperationQueue+Scheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OperationQueue+Scheduler.swift"; sourceTree = "<group>"; };
+		C689E1BA262260BB00B66BDD /* DefaultScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultScheduler.swift; sourceTree = "<group>"; };
+		C689E1BE262260C400B66BDD /* RunLoop+Scheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RunLoop+Scheduler.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -262,6 +272,7 @@
 				4F6637C125C5C5FD00473132 /* SubscriptionCollection.swift */,
 				4F6637C225C5C5FD00473132 /* BidirectionalBindableProperty.swift */,
 				4F6637C325C5C5FD00473132 /* SubscriptionOptions.swift */,
+				C689E1C2262260CB00B66BDD /* Scheduler */,
 				4F6637C425C5C5FD00473132 /* Subscribable+Array.swift */,
 				4F6637C525C5C5FD00473132 /* DisposableBag.swift */,
 				4F6637C625C5C5FD00473132 /* BindingHandlers.swift */,
@@ -423,6 +434,18 @@
 			path = Samples;
 			sourceTree = "<group>";
 		};
+		C689E1C2262260CB00B66BDD /* Scheduler */ = {
+			isa = PBXGroup;
+			children = (
+				C689E1AE2622606100B66BDD /* Scheduler.swift */,
+				C689E1BA262260BB00B66BDD /* DefaultScheduler.swift */,
+				C689E1B22622609500B66BDD /* DispatchQueue+Scheduler.swift */,
+				C689E1B6262260B300B66BDD /* OperationQueue+Scheduler.swift */,
+				C689E1BE262260C400B66BDD /* RunLoop+Scheduler.swift */,
+			);
+			path = Scheduler;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -579,9 +602,11 @@
 			buildActionMask = 2147483647;
 			files = (
 				4F66383825C5C5FD00473132 /* BindingHandler.swift in Sources */,
+				C689E1BF262260C400B66BDD /* RunLoop+Scheduler.swift in Sources */,
 				4F66383425C5C5FD00473132 /* Observable.swift in Sources */,
 				4F66383625C5C5FD00473132 /* DependencyTracker.swift in Sources */,
 				4F66380725C5C5FD00473132 /* Event.swift in Sources */,
+				C689E1AF2622606100B66BDD /* Scheduler.swift in Sources */,
 				4F66381E25C5C5FD00473132 /* UISlider+Binding.swift in Sources */,
 				4F66383525C5C5FD00473132 /* DisposableBlock.swift in Sources */,
 				4F66382D25C5C5FD00473132 /* ComposedBindingHandler.swift in Sources */,
@@ -596,12 +621,14 @@
 				4F66380825C5C5FD00473132 /* UIRefreshControl+Binding.swift in Sources */,
 				4F66380025C5C5FD00473132 /* SubscriptionCollection.swift in Sources */,
 				4F66383725C5C5FD00473132 /* OptionalTypeBindingHandler.swift in Sources */,
+				C689E1B32622609500B66BDD /* DispatchQueue+Scheduler.swift in Sources */,
 				4F66381625C5C5FD00473132 /* AssociatedObjects.swift in Sources */,
 				4F66380A25C5C5FD00473132 /* UIAlertAction+Binding.swift in Sources */,
 				4F66381A25C5C5FD00473132 /* LoadImageBindingHandler.swift in Sources */,
 				4F66382325C5C5FD00473132 /* TargetActionBindableProperty.swift in Sources */,
 				4F66381125C5C5FD00473132 /* UISegmentedControl+Binding.swift in Sources */,
 				4F66381B25C5C5FD00473132 /* LoadImageManager.swift in Sources */,
+				C689E1B7262260B300B66BDD /* OperationQueue+Scheduler.swift in Sources */,
 				4F66383325C5C5FD00473132 /* Fisticuffs.swift in Sources */,
 				4F66382B25C5C5FD00473132 /* Operators.swift in Sources */,
 				4F66382025C5C5FD00473132 /* NSLayoutConstraint+Binding.swift in Sources */,
@@ -626,6 +653,7 @@
 				4F66382125C5C5FD00473132 /* UISearchBar+Binding.swift in Sources */,
 				4F66380225C5C5FD00473132 /* SubscriptionOptions.swift in Sources */,
 				4F66382C25C5C5FD00473132 /* Subscribable.swift in Sources */,
+				C689E1BB262260BB00B66BDD /* DefaultScheduler.swift in Sources */,
 				4F66380B25C5C5FD00473132 /* UIView+Binding.swift in Sources */,
 				4F66381F25C5C5FD00473132 /* UIBarItem+Binding.swift in Sources */,
 				4F66381325C5C5FD00473132 /* UIDatePicker+Binding.swift in Sources */,

--- a/Sources/Fisticuffs/BidirectionalBindableProperty.swift
+++ b/Sources/Fisticuffs/BidirectionalBindableProperty.swift
@@ -75,12 +75,12 @@ public extension BidirectionalBindableProperty {
     ///
     /// - Parameters:
     ///   - observable: The `Observable`
-    ///   - bindingHandler: The custom `BindingHandler`
     ///   - receiveOn: The `Scheduler` for the call back. Defaults to `MainThreadScheduler`
+    ///   - bindingHandler: The custom `BindingHandler`
     func bind<Data>(
         _ observable: Observable<Data>,
-        _ bindingHandler: BindingHandler<Control, Data, ValueType>,
-        receiveOn scheduler: Scheduler = MainThreadScheduler()
+        receiveOn scheduler: Scheduler = MainThreadScheduler(),
+        _ bindingHandler: BindingHandler<Control, Data, ValueType>
     ) {
         currentBinding?.dispose()
         currentBinding = nil
@@ -114,12 +114,12 @@ public extension BidirectionalBindableProperty {
     ///
     /// - Parameters:
     ///   - subscribable: The `Subscribable`
-    ///   - bindingHandler: The custom `BindingHandler`
     ///   - receiveOn: The `Scheduler` for the call back. Defaults to `MainThreadScheduler`
+    ///   - bindingHandler: The custom `BindingHandler`
     func bind<Data>(
         _ subscribable: Subscribable<Data>,
-        _ bindingHandler: BindingHandler<Control, Data, ValueType>,
-        receiveOn scheduler: Scheduler = MainThreadScheduler()
+        receiveOn scheduler: Scheduler = MainThreadScheduler(),
+        _ bindingHandler: BindingHandler<Control, Data, ValueType>
     ) {
         currentBinding?.dispose()
         currentBinding = nil
@@ -141,19 +141,19 @@ public extension BidirectionalBindableProperty where ValueType: OptionalType {
     ///   - observable: The `Observable`
     ///   - receiveOn: The `Scheduler` for the call back. Defaults to `MainThreadScheduler`
     func bind(_ observable: Observable<ValueType.Wrapped>, receiveOn scheduler: Scheduler = MainThreadScheduler()) {
-        bind(observable, DefaultBindingHandler())
+        bind(observable, receiveOn: scheduler, DefaultBindingHandler())
     }
 
     /// Bind property to subscribable
     ///
     /// - Parameters:
     ///   - observable: The `Observable`
-    ///   - bindingHandler: The custom `BindingHandler`
     ///   - receiveOn: The `Scheduler` for the call back. Defaults to `MainThreadScheduler`
+    ///   - bindingHandler: The custom `BindingHandler`
     func bind<Data>(
         _ observable: Observable<Data>,
-        _ bindingHandler: BindingHandler<Control, Data, ValueType.Wrapped>,
-        receiveOn scheduler: Scheduler = MainThreadScheduler()
+        receiveOn scheduler: Scheduler = MainThreadScheduler(),
+        _ bindingHandler: BindingHandler<Control, Data, ValueType.Wrapped>
     ) {
         currentBinding?.dispose()
         currentBinding = nil
@@ -188,12 +188,12 @@ public extension BidirectionalBindableProperty where ValueType: OptionalType {
     ///
     /// - Parameters:
     ///   - subscribable: The `Subscribable`
-    ///   - bindingHandler: The custom `BindingHandler`
     ///   - receiveOn: The `Scheduler` for the call back. Defaults to `MainThreadScheduler`
+    ///   - bindingHandler: The custom `BindingHandler`
     func bind<Data>(
         _ subscribable: Subscribable<Data>,
-        _ bindingHandler: BindingHandler<Control, Data, ValueType.Wrapped>,
-        receiveOn scheduler: Scheduler = MainThreadScheduler()
+        receiveOn scheduler: Scheduler = MainThreadScheduler(),
+        _ bindingHandler: BindingHandler<Control, Data, ValueType.Wrapped>
     ) {
         currentBinding?.dispose()
         currentBinding = nil

--- a/Sources/Fisticuffs/BidirectionalBindableProperty.swift
+++ b/Sources/Fisticuffs/BidirectionalBindableProperty.swift
@@ -62,11 +62,26 @@ extension BidirectionalBindableProperty {
 //MARK: - Binding
 public extension BidirectionalBindableProperty {
     //MARK: Two way binding
-    func bind(_ observable: Observable<ValueType>) {
+    /// Bind property to observable
+    ///
+    /// - Parameters:
+    ///   - observable: The `Observable`
+    ///   - receiveOn: The `Scheduler` for the call back. Defaults to `MainThreadScheduler`
+    func bind(_ observable: Observable<ValueType>, receiveOn scheduler: Scheduler = MainThreadScheduler()) {
         bind(observable, DefaultBindingHandler())
     }
 
-    func bind<Data>(_ observable: Observable<Data>, _ bindingHandler: BindingHandler<Control, Data, ValueType>) {
+    /// Bind property to subscribable
+    ///
+    /// - Parameters:
+    ///   - observable: The `Observable`
+    ///   - bindingHandler: The custom `BindingHandler`
+    ///   - receiveOn: The `Scheduler` for the call back. Defaults to `MainThreadScheduler`
+    func bind<Data>(
+        _ observable: Observable<Data>,
+        _ bindingHandler: BindingHandler<Control, Data, ValueType>,
+        receiveOn scheduler: Scheduler = MainThreadScheduler()
+    ) {
         currentBinding?.dispose()
         currentBinding = nil
 
@@ -74,7 +89,7 @@ public extension BidirectionalBindableProperty {
 
         let disposables = DisposableBag()
 
-        bindingHandler.setup(control, propertySetter: setter, subscribable: observable)
+        bindingHandler.setup(control, propertySetter: setter, subscribable: observable, receiveOn: scheduler)
         disposables.add(bindingHandler)
 
         bindingHandler.setup(getter, changeEvent: uiChangeEvent).subscribe { [weak observable] _, data in
@@ -86,17 +101,32 @@ public extension BidirectionalBindableProperty {
     
     //MARK: One way binding
 
-    func bind(_ subscribable: Subscribable<ValueType>) {
+    /// Bind property to subscribable
+    ///
+    /// - Parameters:
+    ///   - subscribable: The `Subscribable`
+    ///   - receiveOn: The `Scheduler` for the call back. Defaults to `MainThreadScheduler`
+    func bind(_ subscribable: Subscribable<ValueType>, receiveOn scheduler: Scheduler = MainThreadScheduler()) {
         bind(subscribable, DefaultBindingHandler())
     }
 
-    func bind<Data>(_ subscribable: Subscribable<Data>, _ bindingHandler: BindingHandler<Control, Data, ValueType>) {
+    /// Bind property to subscribable
+    ///
+    /// - Parameters:
+    ///   - subscribable: The `Subscribable`
+    ///   - bindingHandler: The custom `BindingHandler`
+    ///   - receiveOn: The `Scheduler` for the call back. Defaults to `MainThreadScheduler`
+    func bind<Data>(
+        _ subscribable: Subscribable<Data>,
+        _ bindingHandler: BindingHandler<Control, Data, ValueType>,
+        receiveOn scheduler: Scheduler = MainThreadScheduler()
+    ) {
         currentBinding?.dispose()
         currentBinding = nil
 
         guard let control = control else { return }
 
-        bindingHandler.setup(control, propertySetter: setter, subscribable: subscribable)
+        bindingHandler.setup(control, propertySetter: setter, subscribable: subscribable, receiveOn: scheduler)
         currentBinding = bindingHandler
     }
 }
@@ -105,11 +135,26 @@ public extension BidirectionalBindableProperty {
 public extension BidirectionalBindableProperty where ValueType: OptionalType {
     //MARK: Two way binding
 
-    func bind(_ observable: Observable<ValueType.Wrapped>) {
+    /// Bind property to subscribable
+    ///
+    /// - Parameters:
+    ///   - observable: The `Observable`
+    ///   - receiveOn: The `Scheduler` for the call back. Defaults to `MainThreadScheduler`
+    func bind(_ observable: Observable<ValueType.Wrapped>, receiveOn scheduler: Scheduler = MainThreadScheduler()) {
         bind(observable, DefaultBindingHandler())
     }
 
-    func bind<Data>(_ observable: Observable<Data>, _ bindingHandler: BindingHandler<Control, Data, ValueType.Wrapped>) {
+    /// Bind property to subscribable
+    ///
+    /// - Parameters:
+    ///   - observable: The `Observable`
+    ///   - bindingHandler: The custom `BindingHandler`
+    ///   - receiveOn: The `Scheduler` for the call back. Defaults to `MainThreadScheduler`
+    func bind<Data>(
+        _ observable: Observable<Data>,
+        _ bindingHandler: BindingHandler<Control, Data, ValueType.Wrapped>,
+        receiveOn scheduler: Scheduler = MainThreadScheduler()
+    ) {
         currentBinding?.dispose()
         currentBinding = nil
 
@@ -118,7 +163,7 @@ public extension BidirectionalBindableProperty where ValueType: OptionalType {
         let disposables = DisposableBag()
 
         let outerBindingHandler = OptionalTypeBindingHandler<Control, Data, ValueType>(innerHandler: bindingHandler)
-        outerBindingHandler.setup(control, propertySetter: setter, subscribable: observable)
+        outerBindingHandler.setup(control, propertySetter: setter, subscribable: observable, receiveOn: scheduler)
         disposables.add(outerBindingHandler)
 
         outerBindingHandler.setup(getter, changeEvent: uiChangeEvent).subscribe { [weak observable] _, data in
@@ -130,11 +175,26 @@ public extension BidirectionalBindableProperty where ValueType: OptionalType {
 
     //MARK: One way binding
 
-    func bind(_ subscribable: Subscribable<ValueType.Wrapped>) {
+    /// Bind property to subscribable
+    ///
+    /// - Parameters:
+    ///   - subscribable: The `Subscribable`
+    ///   - receiveOn: The `Scheduler` for the call back. Defaults to `MainThreadScheduler`
+    func bind(_ subscribable: Subscribable<ValueType.Wrapped>, receiveOn scheduler: Scheduler = MainThreadScheduler()) {
         bind(subscribable, DefaultBindingHandler())
     }
 
-    func bind<Data>(_ subscribable: Subscribable<Data>, _ bindingHandler: BindingHandler<Control, Data, ValueType.Wrapped>) {
+    /// Bind property to subscribable
+    ///
+    /// - Parameters:
+    ///   - subscribable: The `Subscribable`
+    ///   - bindingHandler: The custom `BindingHandler`
+    ///   - receiveOn: The `Scheduler` for the call back. Defaults to `MainThreadScheduler`
+    func bind<Data>(
+        _ subscribable: Subscribable<Data>,
+        _ bindingHandler: BindingHandler<Control, Data, ValueType.Wrapped>,
+        receiveOn scheduler: Scheduler = MainThreadScheduler()
+    ) {
         currentBinding?.dispose()
         currentBinding = nil
 
@@ -142,7 +202,7 @@ public extension BidirectionalBindableProperty where ValueType: OptionalType {
 
         let outerBindingHandler = OptionalTypeBindingHandler<Control, Data, ValueType>(innerHandler: bindingHandler)
 
-        outerBindingHandler.setup(control, propertySetter: setter, subscribable: subscribable)
+        outerBindingHandler.setup(control, propertySetter: setter, subscribable: subscribable, receiveOn: scheduler)
 
         currentBinding = outerBindingHandler
     }

--- a/Sources/Fisticuffs/BindableProperty.swift
+++ b/Sources/Fisticuffs/BindableProperty.swift
@@ -44,19 +44,19 @@ public extension BindableProperty {
     ///   - subscribable: The `Subscribable`
     ///   - receiveOn: The `Scheduler` for the call back. Defaults to `MainThreadScheduler`
     func bind(_ subscribable: Subscribable<ValueType>, receiveOn scheduler: Scheduler = MainThreadScheduler()) {
-        bind(subscribable, DefaultBindingHandler(), receiveOn: scheduler)
+        bind(subscribable, receiveOn: scheduler, DefaultBindingHandler())
     }
 
     /// Bind property to subscribable
     ///
     /// - Parameters:
     ///   - subscribable: The `Subscribable`
-    ///   - bindingHandler: The custom `BindingHandler`
     ///   - receiveOn: The `Scheduler` for the call back. Defaults to `MainThreadScheduler`
+    ///   - bindingHandler: The custom `BindingHandler`
     func bind<Data>(
         _ subscribable: Subscribable<Data>,
-        _ bindingHandler: BindingHandler<Control, Data, ValueType>,
-        receiveOn scheduler: Scheduler = MainThreadScheduler()
+        receiveOn scheduler: Scheduler = MainThreadScheduler(),
+        _ bindingHandler: BindingHandler<Control, Data, ValueType>
     ) {
         currentBinding?.dispose()
         currentBinding = nil
@@ -82,12 +82,12 @@ public extension BindableProperty where ValueType: OptionalType {
     ///
     /// - Parameters:
     ///   - subscribable: The `Subscribable`
-    ///   - bindingHandler: The custom `BindingHandler`
     ///   - receiveOn: The `Scheduler` for the call back. Defaults to `MainThreadScheduler`
+    ///   - bindingHandler: The custom `BindingHandler`
     func bind<Data>(
         _ subscribable: Subscribable<Data>,
-        _ bindingHandler: BindingHandler<Control, Data, ValueType.Wrapped>,
-        receiveOn scheduler: Scheduler = MainThreadScheduler()
+        receiveOn scheduler: Scheduler = MainThreadScheduler(),
+        _ bindingHandler: BindingHandler<Control, Data, ValueType.Wrapped>
     ) {
         currentBinding?.dispose()
         currentBinding = nil

--- a/Sources/Fisticuffs/BindableProperty.swift
+++ b/Sources/Fisticuffs/BindableProperty.swift
@@ -37,31 +37,58 @@ open class BindableProperty<Control: AnyObject, ValueType> {
     }
 }
 
-
-
-
 public extension BindableProperty {
-    func bind(_ subscribable: Subscribable<ValueType>) {
-        bind(subscribable, DefaultBindingHandler())
+    /// Bind property to subscribable
+    ///
+    /// - Parameters:
+    ///   - subscribable: The `Subscribable`
+    ///   - receiveOn: The `Scheduler` for the call back. Defaults to `MainThreadScheduler`
+    func bind(_ subscribable: Subscribable<ValueType>, receiveOn scheduler: Scheduler = MainThreadScheduler()) {
+        bind(subscribable, DefaultBindingHandler(), receiveOn: scheduler)
     }
 
-    func bind<Data>(_ subscribable: Subscribable<Data>, _ bindingHandler: BindingHandler<Control, Data, ValueType>) {
+    /// Bind property to subscribable
+    ///
+    /// - Parameters:
+    ///   - subscribable: The `Subscribable`
+    ///   - bindingHandler: The custom `BindingHandler`
+    ///   - receiveOn: The `Scheduler` for the call back. Defaults to `MainThreadScheduler`
+    func bind<Data>(
+        _ subscribable: Subscribable<Data>,
+        _ bindingHandler: BindingHandler<Control, Data, ValueType>,
+        receiveOn scheduler: Scheduler = MainThreadScheduler()
+    ) {
         currentBinding?.dispose()
         currentBinding = nil
 
         guard let control = control else { return }
 
-        bindingHandler.setup(control, propertySetter: setter, subscribable: subscribable)
+        bindingHandler.setup(control, propertySetter: setter, subscribable: subscribable, receiveOn: scheduler)
         currentBinding = bindingHandler
     }
 }
 
 public extension BindableProperty where ValueType: OptionalType {
-    func bind(_ subscribable: Subscribable<ValueType.Wrapped>) {
+    /// Bind property to subscribable
+    ///
+    /// - Parameters:
+    ///   - subscribable: The `Subscribable`
+    ///   - receiveOn: The `Scheduler` for the call back. Defaults to `MainThreadScheduler`
+    func bind(_ subscribable: Subscribable<ValueType.Wrapped>, receiveOn scheduler: Scheduler = MainThreadScheduler()) {
         bind(subscribable, DefaultBindingHandler())
     }
 
-    func bind<Data>(_ subscribable: Subscribable<Data>, _ bindingHandler: BindingHandler<Control, Data, ValueType.Wrapped>) {
+    /// Bind property to subscribable
+    ///
+    /// - Parameters:
+    ///   - subscribable: The `Subscribable`
+    ///   - bindingHandler: The custom `BindingHandler`
+    ///   - receiveOn: The `Scheduler` for the call back. Defaults to `MainThreadScheduler`
+    func bind<Data>(
+        _ subscribable: Subscribable<Data>,
+        _ bindingHandler: BindingHandler<Control, Data, ValueType.Wrapped>,
+        receiveOn scheduler: Scheduler = MainThreadScheduler()
+    ) {
         currentBinding?.dispose()
         currentBinding = nil
 
@@ -69,7 +96,7 @@ public extension BindableProperty where ValueType: OptionalType {
 
         let outerBindingHandler = OptionalTypeBindingHandler<Control, Data, ValueType>(innerHandler: bindingHandler)
 
-        outerBindingHandler.setup(control, propertySetter: setter, subscribable: subscribable)
+        outerBindingHandler.setup(control, propertySetter: setter, subscribable: subscribable, receiveOn: scheduler)
 
         currentBinding = outerBindingHandler
     }

--- a/Sources/Fisticuffs/BindingHandler.swift
+++ b/Sources/Fisticuffs/BindingHandler.swift
@@ -44,7 +44,8 @@ open class BindingHandler<Control: AnyObject, DataValue, PropertyValue>: Disposa
         self.control = control
         self.propertySetter = propertySetter
 
-        subscribable.subscribe { [weak self] oldValue, newValue in
+        let subscriptionOptions = SubscriptionOptions(receiveOn: MainThreadScheduler())
+        subscribable.subscribe(subscriptionOptions) { [weak self] oldValue, newValue in
             if self?.accessingUnderlyingProperty == true {
                 return
             }
@@ -61,7 +62,8 @@ open class BindingHandler<Control: AnyObject, DataValue, PropertyValue>: Disposa
     func setup(_ propertyGetter: @escaping PropertyGetter, changeEvent: Event<Void>) -> Subscribable<DataValue> {
         self.propertyGetter = propertyGetter
 
-        changeEvent.subscribe { [weak self] _, _ in
+        let subscriptionOptions = SubscriptionOptions(receiveOn: MainThreadScheduler())
+        changeEvent.subscribe(subscriptionOptions) { [weak self] _, _ in
             if self?.accessingUnderlyingProperty == true {
                 return
             }

--- a/Sources/Fisticuffs/BindingHandler.swift
+++ b/Sources/Fisticuffs/BindingHandler.swift
@@ -40,11 +40,16 @@ open class BindingHandler<Control: AnyObject, DataValue, PropertyValue>: Disposa
     public init() { // so we can be subclassed outside of Fisticuffs
     }
 
-    func setup(_ control: Control, propertySetter: @escaping PropertySetter, subscribable: Subscribable<DataValue>) {
+    func setup(
+        _ control: Control,
+        propertySetter: @escaping PropertySetter,
+        subscribable: Subscribable<DataValue>,
+        receiveOn scheduler: Scheduler = MainThreadScheduler()
+    ) {
         self.control = control
         self.propertySetter = propertySetter
 
-        let subscriptionOptions = SubscriptionOptions(receiveOn: MainThreadScheduler())
+        let subscriptionOptions = SubscriptionOptions(receiveOn: scheduler)
         subscribable.subscribe(subscriptionOptions) { [weak self] oldValue, newValue in
             if self?.accessingUnderlyingProperty == true {
                 return
@@ -59,10 +64,15 @@ open class BindingHandler<Control: AnyObject, DataValue, PropertyValue>: Disposa
         .addTo(disposableBag)
     }
 
-    func setup(_ propertyGetter: @escaping PropertyGetter, changeEvent: Event<Void>) -> Subscribable<DataValue> {
+    func setup(
+        _ propertyGetter: @escaping PropertyGetter,
+        changeEvent: Event<Void>,
+        receiveOn scheduler: Scheduler = MainThreadScheduler()
+    ) -> Subscribable<DataValue> {
+
         self.propertyGetter = propertyGetter
 
-        let subscriptionOptions = SubscriptionOptions(receiveOn: MainThreadScheduler())
+        let subscriptionOptions = SubscriptionOptions(receiveOn: scheduler)
         changeEvent.subscribe(subscriptionOptions) { [weak self] _, _ in
             if self?.accessingUnderlyingProperty == true {
                 return

--- a/Sources/Fisticuffs/ComputedBindingHandler.swift
+++ b/Sources/Fisticuffs/ComputedBindingHandler.swift
@@ -43,7 +43,7 @@ open class ComputedBindingHandler<Control: AnyObject, InDataValue, OutDataValue,
         subscription?.dispose()
 
         // so we get oldValue/newValue information, we'll notifyOnSubscription = false, then set it to the new value after
-        let opts = SubscriptionOptions(notifyOnSubscription: false, when: .afterChange)
+        let opts = SubscriptionOptions(notifyOnSubscription: false, when: .afterChange, receiveOn: MainThreadScheduler())
         subscription = computed.subscribe(opts) { [weak self, weak control] oldValue, newValue in
             if let bindingHandler = self?.bindingHandler, let control = control, let oldValue = oldValue, let newValue = newValue {
                 bindingHandler.set(control: control, oldValue: oldValue, value: newValue, propertySetter: propertySetter)

--- a/Sources/Fisticuffs/ComputedBindingHandler.swift
+++ b/Sources/Fisticuffs/ComputedBindingHandler.swift
@@ -39,6 +39,7 @@ open class ComputedBindingHandler<Control: AnyObject, InDataValue, OutDataValue,
         subscription?.dispose()
     }
 
+    /// The callbacks for the computed value will be passed on the main thread
     open override func set(control: Control, oldValue: InDataValue?, value: InDataValue, propertySetter: @escaping PropertySetter) {
         subscription?.dispose()
 

--- a/Sources/Fisticuffs/Scheduler/DefaultScheduler.swift
+++ b/Sources/Fisticuffs/Scheduler/DefaultScheduler.swift
@@ -1,13 +1,28 @@
+//  The MIT License (MIT)
 //
-//  DefaultScheduler.swift
-//  Fisticuffs
+//  Copyright (c) 2021 theScore Inc.
 //
-//  Created by Eugene Kwong on 2021-04-10.
-//  Copyright © 2021 theScore. All rights reserved.
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
 //
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
 
 import Foundation
 
+/// This is the default `Scheduler` which performs work on the current thread
 public final class DefaultScheduler: Scheduler {
     public init() {}
 

--- a/Sources/Fisticuffs/Scheduler/DefaultScheduler.swift
+++ b/Sources/Fisticuffs/Scheduler/DefaultScheduler.swift
@@ -1,0 +1,17 @@
+//
+//  DefaultScheduler.swift
+//  Fisticuffs
+//
+//  Created by Eugene Kwong on 2021-04-10.
+//  Copyright © 2021 theScore. All rights reserved.
+//
+
+import Foundation
+
+public final class DefaultScheduler: Scheduler {
+    public init() {}
+
+    public func schedule(_ action: @escaping () -> Void) {
+        action()
+    }
+}

--- a/Sources/Fisticuffs/Scheduler/DefaultScheduler.swift
+++ b/Sources/Fisticuffs/Scheduler/DefaultScheduler.swift
@@ -23,7 +23,7 @@
 import Foundation
 
 /// This is the default `Scheduler` which performs work on the current thread
-public final class DefaultScheduler: Scheduler {
+public struct DefaultScheduler: Scheduler {
     public init() {}
 
     public func schedule(_ action: @escaping () -> Void) {

--- a/Sources/Fisticuffs/Scheduler/DispatchQueue+Scheduler.swift
+++ b/Sources/Fisticuffs/Scheduler/DispatchQueue+Scheduler.swift
@@ -1,0 +1,17 @@
+//
+//  DispatchQueue+Scheduler.swift
+//  Fisticuffs
+//
+//  Created by Eugene Kwong on 2021-04-10.
+//  Copyright © 2021 theScore. All rights reserved.
+//
+
+import Foundation
+
+extension DispatchQueue: Scheduler {
+    public func schedule(_ action: @escaping () -> Void) {
+        async {
+            action()
+        }
+    }
+}

--- a/Sources/Fisticuffs/Scheduler/MainThreadScheduler.swift
+++ b/Sources/Fisticuffs/Scheduler/MainThreadScheduler.swift
@@ -1,0 +1,40 @@
+//  The MIT License (MIT)
+//
+//  Copyright (c) 2021 theScore Inc.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+import Foundation
+
+/// This is the default `Scheduler` which performs work on the main thread.
+/// It will immediately execute if the current thread is main otherwise dispatches to it
+public struct MainThreadScheduler: Scheduler {
+    public init() {}
+
+    public func schedule(_ action: @escaping () -> Void) {
+        if Thread.isMainThread {
+            action()
+        }
+        else {
+            DispatchQueue.main.async {
+                action()
+            }
+        }
+    }
+}

--- a/Sources/Fisticuffs/Scheduler/OperationQueue+Scheduler.swift
+++ b/Sources/Fisticuffs/Scheduler/OperationQueue+Scheduler.swift
@@ -1,0 +1,15 @@
+//
+//  OperationQueue+Scheduler.swift
+//  Fisticuffs
+//
+//  Created by Eugene Kwong on 2021-04-10.
+//  Copyright © 2021 theScore. All rights reserved.
+//
+
+import Foundation
+
+extension OperationQueue: Scheduler {
+    public func schedule(_ action: @escaping () -> Void) {
+        addOperation(action)
+    }
+}

--- a/Sources/Fisticuffs/Scheduler/OperationQueue+Scheduler.swift
+++ b/Sources/Fisticuffs/Scheduler/OperationQueue+Scheduler.swift
@@ -1,10 +1,24 @@
+//  The MIT License (MIT)
 //
-//  OperationQueue+Scheduler.swift
-//  Fisticuffs
+//  Copyright (c) 2021 theScore Inc.
 //
-//  Created by Eugene Kwong on 2021-04-10.
-//  Copyright © 2021 theScore. All rights reserved.
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
 //
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
 
 import Foundation
 

--- a/Sources/Fisticuffs/Scheduler/RunLoop+Scheduler.swift
+++ b/Sources/Fisticuffs/Scheduler/RunLoop+Scheduler.swift
@@ -1,10 +1,24 @@
+//  The MIT License (MIT)
 //
-//  RunLoop+Scheduler.swift
-//  Fisticuffs
+//  Copyright (c) 2021 theScore Inc.
 //
-//  Created by Eugene Kwong on 2021-04-10.
-//  Copyright © 2021 theScore. All rights reserved.
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
 //
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
 
 import Foundation
 

--- a/Sources/Fisticuffs/Scheduler/RunLoop+Scheduler.swift
+++ b/Sources/Fisticuffs/Scheduler/RunLoop+Scheduler.swift
@@ -1,0 +1,24 @@
+//
+//  RunLoop+Scheduler.swift
+//  Fisticuffs
+//
+//  Created by Eugene Kwong on 2021-04-10.
+//  Copyright © 2021 theScore. All rights reserved.
+//
+
+import Foundation
+
+extension RunLoop: Scheduler {
+    public func schedule(_ action: @escaping () -> Void) {
+        if #available(iOS 10.0, *) {
+            perform {
+                action()
+            }
+        }
+        else {
+            CFRunLoopPerformBlock(getCFRunLoop(), CFRunLoopMode.defaultMode.rawValue) {
+                action()
+            }
+        }
+    }
+}

--- a/Sources/Fisticuffs/Scheduler/Scheduler.swift
+++ b/Sources/Fisticuffs/Scheduler/Scheduler.swift
@@ -1,0 +1,13 @@
+//
+//  Scheduler.swift
+//  Fisticuffs
+//
+//  Created by Eugene Kwong on 2021-04-10.
+//  Copyright © 2021 theScore. All rights reserved.
+//
+
+import Foundation
+
+public protocol Scheduler {
+    func schedule(_ action: @escaping () -> Void)
+}

--- a/Sources/Fisticuffs/Scheduler/Scheduler.swift
+++ b/Sources/Fisticuffs/Scheduler/Scheduler.swift
@@ -1,13 +1,29 @@
+//  The MIT License (MIT)
 //
-//  Scheduler.swift
-//  Fisticuffs
+//  Copyright (c) 2021 theScore Inc.
 //
-//  Created by Eugene Kwong on 2021-04-10.
-//  Copyright © 2021 theScore. All rights reserved.
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
 //
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
 
 import Foundation
 
+/// A protocol that defines when and how to execute a closure
 public protocol Scheduler {
+    /// Performs the action at the next possible opportunity
     func schedule(_ action: @escaping () -> Void)
 }

--- a/Sources/Fisticuffs/Scheduler/Scheduler.swift
+++ b/Sources/Fisticuffs/Scheduler/Scheduler.swift
@@ -22,7 +22,9 @@
 
 import Foundation
 
-/// A protocol that defines when and how to execute a closure
+/// A protocol that defines how to execute a closure
+///
+/// - Remark: In the future this can be expanded to define *when* as well
 public protocol Scheduler {
     /// Performs the action at the next possible opportunity
     func schedule(_ action: @escaping () -> Void)

--- a/Sources/Fisticuffs/Subscribable.swift
+++ b/Sources/Fisticuffs/Subscribable.swift
@@ -37,7 +37,7 @@ open class Subscribable<Value> : AnySubscribable {
     open func subscribe(_ options: SubscriptionOptions, block: @escaping (Value?, Value) -> Void) -> Disposable {
         let currentValue = self.currentValue
 
-        let disposable = subscriptionCollection.add(when: options.when, recieveOn: options.scheduler, callback: block)
+        let disposable = subscriptionCollection.add(when: options.when, receiveOn: options.scheduler, callback: block)
         if let value = currentValue, options.notifyOnSubscription {
             options.scheduler.schedule {
                 block(value, value)

--- a/Sources/Fisticuffs/Subscribable.swift
+++ b/Sources/Fisticuffs/Subscribable.swift
@@ -37,9 +37,11 @@ open class Subscribable<Value> : AnySubscribable {
     open func subscribe(_ options: SubscriptionOptions, block: @escaping (Value?, Value) -> Void) -> Disposable {
         let currentValue = self.currentValue
 
-        let disposable = subscriptionCollection.add(when: options.when, callback: block)
-        if let value = currentValue , options.notifyOnSubscription {
-            block(value, value)
+        let disposable = subscriptionCollection.add(when: options.when, recieveOn: options.scheduler, callback: block)
+        if let value = currentValue, options.notifyOnSubscription {
+            options.scheduler.schedule {
+                block(value, value)
+            }
         }
         return disposable
     }

--- a/Sources/Fisticuffs/SubscriptionCollection.swift
+++ b/Sources/Fisticuffs/SubscriptionCollection.swift
@@ -26,9 +26,9 @@ open class SubscriptionCollection<T> {
     fileprivate var subscriptions = [Subscription<T>]()
     fileprivate let lock = NSRecursiveLock()
     
-    func add(when: NotifyWhen, recieveOn: Scheduler, callback: @escaping (T?, T) -> Void) -> Disposable {
+    func add(when: NotifyWhen, receiveOn: Scheduler, callback: @escaping (T?, T) -> Void) -> Disposable {
         lock.withLock {
-            let subscription = Subscription(callback: callback, when: when, receiveOn: recieveOn, subscriptionCollection: self)
+            let subscription = Subscription(callback: callback, when: when, receiveOn: receiveOn, subscriptionCollection: self)
             subscriptions.append(subscription)
             return subscription
         }
@@ -36,9 +36,9 @@ open class SubscriptionCollection<T> {
     
     public func notify(time: NotifyWhen, old: T?, new: T) {
         lock.withLock {
-            for s in subscriptions where s.when == time {
-                s.scheduler.schedule {
-                    s.callback(old, new)
+            for subscription in subscriptions where subscription.when == time {
+                subscription.scheduler.schedule {
+                    subscription.callback(old, new)
                 }
             }
         }

--- a/Sources/Fisticuffs/SubscriptionOptions.swift
+++ b/Sources/Fisticuffs/SubscriptionOptions.swift
@@ -32,12 +32,19 @@ public enum NotifyWhen {
 public struct SubscriptionOptions {
     public var notifyOnSubscription = true
     public var when = NotifyWhen.afterChange
-    
+    public let scheduler: Scheduler
+
     public init() {
+        self.scheduler = DefaultScheduler()
     }
-    
-    public init(notifyOnSubscription: Bool, when: NotifyWhen) {
+
+    public init(recieveOn: Scheduler) {
+        self.scheduler = recieveOn
+    }
+
+    public init(notifyOnSubscription: Bool, when: NotifyWhen, recieveOn: Scheduler = DefaultScheduler()) {
         self.notifyOnSubscription = notifyOnSubscription
         self.when = when
+        self.scheduler = recieveOn
     }
 }

--- a/Sources/Fisticuffs/SubscriptionOptions.swift
+++ b/Sources/Fisticuffs/SubscriptionOptions.swift
@@ -38,13 +38,13 @@ public struct SubscriptionOptions {
         self.scheduler = DefaultScheduler()
     }
 
-    public init(recieveOn: Scheduler) {
-        self.scheduler = recieveOn
+    public init(receiveOn: Scheduler) {
+        self.scheduler = receiveOn
     }
 
-    public init(notifyOnSubscription: Bool, when: NotifyWhen, recieveOn: Scheduler = DefaultScheduler()) {
+    public init(notifyOnSubscription: Bool, when: NotifyWhen, receiveOn: Scheduler = DefaultScheduler()) {
         self.notifyOnSubscription = notifyOnSubscription
         self.when = when
-        self.scheduler = recieveOn
+        self.scheduler = receiveOn
     }
 }

--- a/Tests/FisticuffsTests/SchedulersSpec.swift
+++ b/Tests/FisticuffsTests/SchedulersSpec.swift
@@ -1,0 +1,87 @@
+//  The MIT License (MIT)
+//
+//  Copyright (c) 2021 theScore Inc.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+import Foundation
+import Quick
+import Nimble
+@testable import Fisticuffs
+
+class SchedulersSpec: QuickSpec {
+    override func spec() {
+        describe("DispatchQueue Scheduler") {
+            it("should perform action in the given queue") {
+                let expectation = self.expectation(description: "wait")
+
+                let backgroundThread = DispatchQueue(label: "background thread")
+
+                let scheduler = DispatchQueue.main
+
+                backgroundThread.async {
+                    scheduler.schedule {
+                        expect(Thread.isMainThread).to(beTrue())
+                        expectation.fulfill()
+                    }
+                }
+
+                self.wait(for: [expectation], timeout: 5)
+            }
+        }
+
+        describe("RunLoop Scheduler") {
+            it("should perform action") {
+                let expectation = self.expectation(description: "wait")
+
+                let backgroundThread = DispatchQueue(label: "background thread")
+
+                let scheduler = RunLoop.main
+
+                backgroundThread.async {
+                    scheduler.schedule {
+                        expect(Thread.isMainThread).to(beTrue())
+                        expectation.fulfill()
+                    }
+                }
+
+                self.wait(for: [expectation], timeout: 5)
+            }
+        }
+
+        describe("OperationQueue Scheduler") {
+            it("should perform action") {
+                let expectation = self.expectation(description: "wait")
+
+                let backgroundThread = DispatchQueue(label: "background thread")
+
+                let scheduler = OperationQueue.main
+
+                backgroundThread.async {
+                    scheduler.schedule {
+                        expect(Thread.isMainThread).to(beTrue())
+                        expectation.fulfill()
+                    }
+                }
+
+                self.wait(for: [expectation], timeout: 5)
+            }
+        }
+    }
+}

--- a/Tests/FisticuffsTests/SchedulersSpec.swift
+++ b/Tests/FisticuffsTests/SchedulersSpec.swift
@@ -33,10 +33,10 @@ class SchedulersSpec: QuickSpec {
 
                 let backgroundThread = DispatchQueue(label: "background thread")
 
-                let scheduler = DispatchQueue.main
+                let subject = DispatchQueue.main
 
                 backgroundThread.async {
-                    scheduler.schedule {
+                    subject.schedule {
                         expect(Thread.isMainThread).to(beTrue())
                         expectation.fulfill()
                     }
@@ -52,10 +52,10 @@ class SchedulersSpec: QuickSpec {
 
                 let backgroundThread = DispatchQueue(label: "background thread")
 
-                let scheduler = RunLoop.main
+                let subject = RunLoop.main
 
                 backgroundThread.async {
-                    scheduler.schedule {
+                    subject.schedule {
                         expect(Thread.isMainThread).to(beTrue())
                         expectation.fulfill()
                     }
@@ -71,16 +71,60 @@ class SchedulersSpec: QuickSpec {
 
                 let backgroundThread = DispatchQueue(label: "background thread")
 
-                let scheduler = OperationQueue.main
+                let subject = OperationQueue.main
 
                 backgroundThread.async {
-                    scheduler.schedule {
+                    subject.schedule {
                         expect(Thread.isMainThread).to(beTrue())
                         expectation.fulfill()
                     }
                 }
 
                 self.wait(for: [expectation], timeout: 5)
+            }
+        }
+
+        describe("MainThreadScheduler") {
+            var subject: MainThreadScheduler!
+
+            beforeEach {
+                subject = MainThreadScheduler()
+            }
+
+            it("should perform action on main thread") {
+                let expectation = self.expectation(description: "wait")
+
+                let backgroundThread = DispatchQueue(label: "background thread")
+
+                backgroundThread.async {
+                    subject.schedule {
+                        expect(Thread.isMainThread).to(beTrue())
+                        expectation.fulfill()
+                    }
+                }
+
+                self.wait(for: [expectation], timeout: 5)
+            }
+
+            it("should perform action immediately if current thread is main") {
+                let expectation = self.expectation(description: "scheduler")
+                let expectation2 = self.expectation(description: "main")
+
+                var numbers = [Int]()
+
+                DispatchQueue.main.async {
+                    subject.schedule {
+                        numbers.append(1)
+                        expectation.fulfill()
+                    }
+
+                    numbers.append(2)
+                    expectation2.fulfill()
+                }
+
+                self.wait(for: [expectation, expectation2], timeout: 5)
+                
+                expect(numbers) == [1,2]
             }
         }
     }


### PR DESCRIPTION
Allows more granular control of where the callback is performed for subscribers.

The idea is based off Combine and RxSwift Schedulers, which dictates the **where** and **when** work will be performed. At the moment this implementation is pretty basic as it only contains the **where**, but this serves as a building block for further expansion.

Adds default implementation to `DispatchQueue`, `RunLoop`, and `OperationQueue` so those can be passed in directly to `SubscriptionOptions`. If nothing is passed it creates a generic `DefaultScheduler` which basically represents the current running thread, i.e. the existing behaviour. 

To Do
----
- [x] Documentation
- [x] Unit tests