### PR TITLE
Make any subscribable type conform to hashable

### DIFF
--- a/Sources/Fisticuffs/Subscribable+Hashable.swift
+++ b/Sources/Fisticuffs/Subscribable+Hashable.swift
@@ -1,0 +1,33 @@
+//  The MIT License (MIT)
+//
+//  Copyright (c) 2015 theScore Inc.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+extension Subscribable: Equatable where Value: Hashable {
+    public static func == (lhs: Subscribable<Value>, rhs: Subscribable<Value>) -> Bool {
+        lhs.currentValue == rhs.currentValue
+    }
+}
+
+extension Subscribable: Hashable where Value: Hashable {
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(currentValue)
+    }
+}


### PR DESCRIPTION
Currently the `Subscribable` types like `Observable` or `Computed` don't support `Hashable`. To introduce support for `Hashable` I'm adding a conditional conformance for `Hashable` types where if the contained type supports it then the `Subscribable` itself would be hashable.