### PR TITLE
Change the bump version action permissions

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Check Acccess
         uses: scoremedia/action-repository-permission@v2
         with:
-          required-permission: admin
+          required-permission: write
 
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
Allow anyone with write access to be able to bump the version because admins aren't the only ones that will be bumping this version