### PR TITLE
Convert to using UIAction based API

### DIFF
--- a/Sources/Fisticuffs/UIKit/TargetActionBindableProperty.swift
+++ b/Sources/Fisticuffs/UIKit/TargetActionBindableProperty.swift
@@ -15,14 +15,13 @@ class TargetActionBindableProperty<Control: UIControl, ValueType>: Bidirectional
 
     init(control: Control, getter: @escaping Getter, setter: @escaping Setter, events: UIControl.Event) {
         super.init(control: control, getter: getter, setter: setter, extraCleanup: disposables)
-        control.addTarget(self, action: #selector(TargetActionBindableProperty.controlEventFired), for: events)
-        disposables.add(DisposableBlock { [weak self, weak control] in
-            control?.removeTarget(self, action: #selector(TargetActionBindableProperty.controlEventFired), for: events)
+        let actionId = UIAction.Identifier(UUID().uuidString)
+        control.addAction(.init(identifier: actionId,handler: { [weak self] _ in
+            guard let self else { return }
+            self.pushChangeToCurrentValueSubscribable()
+        }), for: events)
+        disposables.add(DisposableBlock { [weak control] in
+            control?.removeAction(identifiedBy: actionId, for: events)
         })
     }
-
-    @objc func controlEventFired() {
-        self.pushChangeToCurrentValueSubscribable()
-    }
-
 }

--- a/Sources/Fisticuffs/UIKit/UIControl+Binding.swift
+++ b/Sources/Fisticuffs/UIKit/UIControl+Binding.swift
@@ -66,8 +66,7 @@ public extension UIControl {
             return trampoline.event
         } else {
             let trampoline = ControlEventTrampoline()
-            addAction(.init(handler: { [weak self] _ in
-                guard let self else { return }
+            addAction(.init(handler: { _ in
                 // cannot get `UIEvent` from a UIAction
                 trampoline.event.fire(nil)
             }), for: controlEvents)

--- a/Sources/Fisticuffs/UIKit/UISegmentedControl+Binding.swift
+++ b/Sources/Fisticuffs/UIKit/UISegmentedControl+Binding.swift
@@ -68,7 +68,7 @@ private class SegmentControlManager<Item: Equatable> : NSObject {
         
         control.addAction(.init(identifier: actionID, handler: { [weak self] _ in
             guard let self else { return }
-            selection.value = itemValues[control.selectedSegmentIndex]
+            selection.value = self.itemValues[control.selectedSegmentIndex]
         }), for: .valueChanged)
     }
 


### PR DESCRIPTION
The target based API is more or less replaced by the new action based api for UIControl. The old methods are not deprecated but they require a running UIApplication in order to send or receive events. This API doesn't have that limitation so we can leverage it in unit tests better